### PR TITLE
Add typography helper

### DIFF
--- a/static-layout/public/index.html
+++ b/static-layout/public/index.html
@@ -12,9 +12,11 @@
       font-family: 'Playfair Display', serif;
       font-family: 'Playfair Display SC', serif;
       font-family: 'Libre Franklin', sans-serif;
+      font-family: 'Gothic A1', sans-serif; // light: 300, regular: 400, semi-bold: 600, bold: 700
     -->
   <link href="https://fonts.googleapis.com/css?family=Playfair+Display|Playfair+Display+SC" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Libre+Franklin" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Gothic+A1:300,400,600,700" rel="stylesheet">
 
 </head>
 

--- a/static-layout/src/components/Navigation.jsx
+++ b/static-layout/src/components/Navigation.jsx
@@ -8,7 +8,7 @@ import { Serif } from "./Typography"
 const LinkItem = props => {
   return (
     <Box mr={3} mt={3}>
-      <Serif color="black60" fontSize={[2]}>
+      <Serif color="black60" size="5">
         <Link
           to={props.to}
           getProps={({ isCurrent }) =>

--- a/static-layout/src/components/SubscribeForm.jsx
+++ b/static-layout/src/components/SubscribeForm.jsx
@@ -19,7 +19,7 @@ export const SubscribeForm = () => {
 }
 
 const Input = styled.input`
-  font-family: ${props => props.theme.fonts.sans};
+  font-family: ${props => props.theme.typography.family.sans};
   height: ${space(2)};
   width: 100%;
 `

--- a/static-layout/src/components/Typography.jsx
+++ b/static-layout/src/components/Typography.jsx
@@ -1,5 +1,71 @@
 import React from "react"
-import { Text } from "rebass"
+import styled from "styled-components"
+import { Text as TextBase } from "rebass"
+import { theme } from "../theme"
 
-export const Sans = props => <Text fontFamily="sans" {...props} />
-export const Serif = props => <Text fontFamily="serif" {...props} />
+/**
+ * Typography helpers can be used like so:
+ *
+ * <Sans size='3' weight='bold'>Hello</Sans>
+ *
+ * Or responsive:
+ *
+ * <Sans size={['3', '4']}>How are you</Sans>
+ *
+ */
+export const Sans = props => buildType({ fontFamily: "sans", ...props })
+export const Serif = props => buildType({ fontFamily: "serif", ...props })
+
+function buildType({
+  fontFamily = "sans",
+  size = "3",
+  weight = "regular",
+  children,
+}) {
+  const { fontSize, lineHeight } = determineFontSizes(size)
+  const fontWeight = theme.typography.weights[weight]
+  const textProps = {
+    fontSize,
+    fontFamily,
+    fontWeight,
+    lineHeight,
+  }
+
+  return <Text {...textProps}>{children}</Text>
+}
+
+const Text = styled(TextBase)`
+  font-family: ${props => props.fontFamily};
+  font-size: ${props => props.fontSize}px;
+  font-weight: ${props => props.fontWeight};
+  line-height: ${props => props.lineHeight}px;
+`
+
+/**
+ * Determines which font sizes/line heights to use for typography, and checks to
+ * see if the values being passed in are responsive.
+ *
+ * See: https://jxnblk.com/styled-system/#responsive-styles
+ */
+function determineFontSizes(size) {
+  if (!Array.isArray(size)) {
+    const { fontSize, lineHeight } = theme.typography.sizes[size]
+
+    return {
+      fontSize: `${fontSize}px`,
+      lineHeight: `${lineHeight}px`,
+    }
+  }
+
+  return size
+    .map(s => theme.typography.sizes[s])
+    .reduce(
+      (accumulator, current) => {
+        return {
+          fontSize: [...accumulator.fontSize, `${current.fontSize}px`],
+          lineHeight: [...accumulator.lineHeight, `${current.lineHeight}px`],
+        }
+      },
+      { fontSize: [], lineHeight: [] }
+    )
+}

--- a/static-layout/src/routes/Ephemera.jsx
+++ b/static-layout/src/routes/Ephemera.jsx
@@ -5,9 +5,9 @@ import { Box, Flex, Image, Button } from "rebass"
 export const Ephemera = () => {
   return (
     <Flex>
-      {merch.map(item => {
+      {merch.map((item, index) => {
         return (
-          <Box>
+          <Box key={index}>
             <Box>
               <Image src={item.image} />
             </Box>

--- a/static-layout/src/routes/Release.jsx
+++ b/static-layout/src/routes/Release.jsx
@@ -96,25 +96,24 @@ export const Release = () => {
 
           <p>
             <a href="#f">Fifteen Questions Interview with Werner Durand</a>
+          </p>
 
-            <p>
-              “There are times when I wish I could just stay inside the music,
-              not because I reject so-called reality, but because I experience
-              it as a kind of ideal one. Setting up situations where this can
-              happen for both performers and audiences should be a goal. The
-              Dream House concept by La Monte Young is a very good example. Just
-              let the dream come true.”
-            </p>
+          <p>
+            “There are times when I wish I could just stay inside the music, not
+            because I reject so-called reality, but because I experience it as a
+            kind of ideal one. Setting up situations where this can happen for
+            both performers and audiences should be a goal. The Dream House
+            concept by La Monte Young is a very good example. Just let the dream
+            come true.”
           </p>
 
           <p>
             <a href="#f">Sam Ashley on the Meaning of Trance</a>
+          </p>
 
-            <p>
-              Lucrecia Dalt dives into the world of trance and hypnagagogic
-              states with experimental composer and performance artist Sam
-              Ashley
-            </p>
+          <p>
+            Lucrecia Dalt dives into the world of trance and hypnagagogic states
+            with experimental composer and performance artist Sam Ashley
           </p>
 
           <Serif>Press</Serif>

--- a/static-layout/src/theme.jsx
+++ b/static-layout/src/theme.jsx
@@ -1,7 +1,17 @@
 import { createGlobalStyle } from "styled-components"
 import backgroundImage from "./assets/background-gradient.png"
 
+const breakpoints = {
+  xl: 1200,
+  lg: 1024,
+  md: 900,
+  sm: 768,
+  xs: 767,
+}
+
 export const theme = {
+  breakpoints: [breakpoints.sm, breakpoints.md, breakpoints.lg, breakpoints.xl],
+
   colors: {
     black100: "#000",
     black80: "#333",
@@ -16,9 +26,47 @@ export const theme = {
     teal: "#6faece",
   },
 
-  fonts: {
-    sans: "Libre Franklin",
-    serif: "Playfair Display",
+  typography: {
+    family: {
+      sans: "Gothic A1",
+      serif: "Playfair Display",
+    },
+    weights: {
+      light: 300,
+      regular: 400,
+      semiBold: 600,
+      bold: 700,
+    },
+    sizes: {
+      "0": {
+        fontSize: 8,
+        lineHeight: 8,
+      },
+      "1": {
+        fontSize: 10,
+        lineHeight: 14,
+      },
+      "2": {
+        fontSize: 12,
+        lineHeight: 16,
+      },
+      "3": {
+        fontSize: 14,
+        lineHeight: 24,
+      },
+      "4": {
+        fontSize: 16,
+        lineHeight: 26,
+      },
+      "5": {
+        fontSize: 18,
+        lineHeight: 30,
+      },
+      "6": {
+        fontSize: 22,
+        lineHeight: 30,
+      },
+    },
   },
 
   /**
@@ -42,15 +90,16 @@ export const theme = {
 }
 
 // Helpers
-export const color = colorKey => theme.colors[colorKey] + "px"
+export const color = colorKey => theme.colors[colorKey]
 export const space = spaceKey => theme.space[spaceKey] + "px"
 
 // Globals
 export const GlobalStyle = createGlobalStyle`
   body, html {
     background: url(${backgroundImage});
-    font-family: 'Libre Franklin', sans-serif;
+    font-family: 'Gothic A1', sans-serif;
     line-height: 1.5;
+    color: ${color("black60")};
   }
 
   a {


### PR DESCRIPTION
Updates our Typography helpers to be a little more useful. Can be used like:

```
<Sans size="3" weight="bold" />
<Serif size="4" weight="semiBold" />
```

And when we start wiring up the responsive mobile layout the `size` prop can also take an array:
```
<Sans size={["3", "4"}] weight="bold" />
```

Meaning, when the viewport is really narrow ('xs', or extra small) the size is 3. Anything greater than xs it's 4. 

If adding intermediate breakpoints (like medium or large) the array expands:

```
<Sans size={["3", "4", "5", "6"]} />
```

- xs: 3
- s: 4
- m: 5
- l: 6

Note that I stole this idea from my work's [design system, Palette](https://palette.artsy.net) and just pulled some of the code over here.
