### PR TITLE
Begin adding responsiveness

### DIFF
--- a/static-layout/package.json
+++ b/static-layout/package.json
@@ -32,8 +32,10 @@
     "lodash": "^4.17.11",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
+    "react-media": "^1.9.2",
     "react-scripts": "2.1.5",
     "react-twitter-embed": "^2.0.4",
+    "reactn": "^1.0.0",
     "rebass": "^3.0.1",
     "styled-components": "^4.1.3"
   }

--- a/static-layout/src/components/BorderBox.jsx
+++ b/static-layout/src/components/BorderBox.jsx
@@ -4,6 +4,6 @@ import styled from "styled-components"
 
 export const BorderBox = styled(Box).attrs({ p: 2 })`
   border-radius: 3px;
-  border: 1px solid ${p => p.theme.colors.black10};
+  border: 1px solid ${p => p.theme.colors[p.borderColor || "black10"]};
   height: fit-content;
 `

--- a/static-layout/src/components/Layout.jsx
+++ b/static-layout/src/components/Layout.jsx
@@ -1,20 +1,30 @@
 import React from "react"
 import styled from "styled-components"
-
+import { setGlobal, useGlobal } from "reactn"
+import { Box } from "rebass"
 import { Logo } from "./Logo"
 import { Navigation } from "./Navigation"
-import { Box } from "rebass"
-import { space } from "../theme"
 import { Footer } from "./Footer"
 
+setGlobal({
+  mobileNavOpen: false,
+})
+
 export const Layout = ({ children }) => {
+  const [state] = useGlobal()
+
   return (
     <>
-      <Container>
-        <Logo />
-        <Navigation />
-
-        <Box mt={8}>{children}</Box>
+      <Container p={[1, 4]}>
+        {state.mobileNavOpen ? (
+          <Navigation />
+        ) : (
+          <>
+            <Logo />
+            <Navigation />
+            <Box mt={8}>{children}</Box>
+          </>
+        )}
       </Container>
       <Footer />
     </>
@@ -26,5 +36,4 @@ const Container = styled(Box)`
   min-height: 94vh;
   height: 100%;
   margin: 0 auto;
-  padding: ${space("4")};
 `

--- a/static-layout/src/components/Logo.jsx
+++ b/static-layout/src/components/Logo.jsx
@@ -1,16 +1,33 @@
 import React from "react"
 import { Box, Flex } from "rebass"
-import { ReactComponent as LogoDesktop } from "../assets/LogoDesktop.svg"
+import Media from "react-media"
 import { Link } from "@reach/router"
+import { ReactComponent as LogoDesktop } from "../assets/LogoDesktop.svg"
+import { ReactComponent as LogoMobile } from "../assets/LogoMobile.svg"
+import { breakpoints } from "../theme"
 
 export const Logo = () => {
   return (
     <Flex justifyContent="center">
-      <Box width={370} height={90}>
-        <Link to="/">
-          <LogoDesktop />
-        </Link>
-      </Box>
+      <Link to="/">
+        <Media query={{ maxWidth: breakpoints.sm }}>
+          {mobile => {
+            if (mobile) {
+              return (
+                <Box mt={4}>
+                  <LogoMobile width={100} />
+                </Box>
+              )
+            } else {
+              return (
+                <Box width={370} height={90}>
+                  <LogoDesktop />
+                </Box>
+              )
+            }
+          }}
+        </Media>
+      </Link>
     </Flex>
   )
 }

--- a/static-layout/src/components/Navigation.jsx
+++ b/static-layout/src/components/Navigation.jsx
@@ -1,14 +1,19 @@
 import React from "react"
 import { Box, Flex, Image } from "rebass"
 import { Link } from "@reach/router"
+import Media from "react-media"
 import styled from "styled-components"
+import { useGlobal } from "reactn"
 import { color } from "../theme"
 import { Serif } from "./Typography"
+import { Spacer } from "./Spacer"
+import { breakpoints } from "../theme"
+import { ReactComponent as NavToggle } from "../assets/NavToggle.svg"
 
 const LinkItem = props => {
   return (
     <Box mr={3}>
-      <Serif color="black60" size="4">
+      <Serif color="black60" size={["6", "4"]}>
         <Link
           to={props.to}
           getProps={({ isCurrent }) =>
@@ -16,6 +21,7 @@ const LinkItem = props => {
           }
           style={{
             whiteSpace: "nowrap",
+            userSelect: "none",
           }}
         >
           {props.children}
@@ -26,10 +32,10 @@ const LinkItem = props => {
 }
 
 const SocialLink = props => {
-  const size = 20
+  const size = [40, 20]
 
   return (
-    <Box width={size} height={size} m="3px" mt={1}>
+    <Box width={size} height={size} mt={1} m={[1, "3px"]}>
       <a href={props.url} target="_blank" rel="noopener noreferrer">
         <Image src={props.image} />
       </a>
@@ -37,46 +43,104 @@ const SocialLink = props => {
   )
 }
 
+const NavItems = () => {
+  return (
+    <Flex flexDirection={["column", "row"]}>
+      <LinkItem to="/">Home</LinkItem>
+      <LinkItem to="/all-releases">All Releases</LinkItem>
+      <LinkItem to="/release">Release</LinkItem>
+      <LinkItem to="/artists">Artists</LinkItem>
+      <LinkItem to="/artist">Artist</LinkItem>
+      <LinkItem to="/about">About</LinkItem>
+      <LinkItem to="/news">News</LinkItem>
+      <LinkItem to="/ephemera">Ephemera</LinkItem>
+    </Flex>
+  )
+}
+
+const SocialItems = () => {
+  return (
+    <Flex
+      flexWrap={["wrap", ""]}
+      px={[2, 0]}
+      justifyContent="flex-end"
+      width="100%"
+    >
+      <SocialLink
+        url="https://unseenworlds.bandcamp.com/"
+        image={require("../assets/social/rounded-bandcamp.png")}
+      />
+      <SocialLink
+        url="https://open.spotify.com/user/unseenworlds"
+        image={require("../assets/social/rounded-spotify.png")}
+      />
+      <SocialLink
+        url="https://itunes.apple.com/profile/unseenworlds"
+        image={require("../assets/social/rounded-apple-music.png")}
+      />
+      <SocialLink
+        url="https://twitter.com/Unseen_Worlds"
+        image={require("../assets/social/rounded-twitter.png")}
+      />
+      <SocialLink
+        url="https://www.instagram.com/unseen_worlds"
+        image={require("../assets/social/rounded-instagram.png")}
+      />
+      <SocialLink
+        url="https://www.facebook.com/unseenworlds"
+        image={require("../assets/social/rounded-facebook.png")}
+      />
+    </Flex>
+  )
+}
+
 export const Navigation = () => {
   return (
-    <Container my={5} alignItems="center">
-      <Flex>
-        <LinkItem to="/">Home</LinkItem>
-        <LinkItem to="/all-releases">All Releases</LinkItem>
-        <LinkItem to="/release">Release</LinkItem>
-        <LinkItem to="/artists">Artists</LinkItem>
-        <LinkItem to="/artist">Artist</LinkItem>
-        <LinkItem to="/about">About</LinkItem>
-        <LinkItem to="/news">News</LinkItem>
-        <LinkItem to="/ephemera">Ephemera</LinkItem>
-      </Flex>
-      <Flex alignItems="center" justifyContent="flex-end" width="100%">
-        <SocialLink
-          url="https://unseenworlds.bandcamp.com/"
-          image={require("../assets/social/rounded-bandcamp.png")}
-        />
-        <SocialLink
-          url="https://open.spotify.com/user/unseenworlds"
-          image={require("../assets/social/rounded-spotify.png")}
-        />
-        <SocialLink
-          url="https://itunes.apple.com/profile/unseenworlds"
-          image={require("../assets/social/rounded-apple-music.png")}
-        />
-        <SocialLink
-          url="https://twitter.com/Unseen_Worlds"
-          image={require("../assets/social/rounded-twitter.png")}
-        />
-        <SocialLink
-          url="https://www.instagram.com/unseen_worlds"
-          image={require("../assets/social/rounded-instagram.png")}
-        />
-        <SocialLink
-          url="https://www.facebook.com/unseenworlds"
-          image={require("../assets/social/rounded-facebook.png")}
-        />
-      </Flex>
+    <Media query={{ maxWidth: breakpoints.sm }}>
+      {mobile => {
+        if (mobile) {
+          return <MobileNavigation />
+        } else {
+          return <DesktopNavigation />
+        }
+      }}
+    </Media>
+  )
+}
+
+const DesktopNavigation = () => {
+  return (
+    <Container my={5} alignItems="center" flexDirection="row">
+      <NavItems />
+      <SocialItems />
     </Container>
+  )
+}
+
+const MobileNavigation = () => {
+  const [isOpen, toggleOpen] = useGlobal("mobileNavOpen")
+
+  return (
+    <MobileContainer onClick={() => toggleOpen(!isOpen)}>
+      <NavToggle
+        style={{
+          position: "absolute",
+          opacity: 0.3,
+        }}
+      />
+      {isOpen && (
+        <Container
+          my={5}
+          alignItems="flex-start"
+          flexDirection="row"
+          width="100%"
+        >
+          <NavItems />
+          <Spacer my={2} />
+          <SocialItems />
+        </Container>
+      )}
+    </MobileContainer>
   )
 }
 
@@ -93,4 +157,10 @@ const Container = styled(Flex)`
   .active {
     color: ${color("purpleDark")};
   }
+`
+
+const MobileContainer = styled(Box)`
+  cursor: pointer;
+  position: absolute;
+  top: 20px;
 `

--- a/static-layout/src/routes/Home.jsx
+++ b/static-layout/src/routes/Home.jsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { Box, Flex, Image } from "rebass"
 import { TwitterTimelineEmbed } from "react-twitter-embed"
+import { take } from "lodash"
+import { releases } from "../data"
+import { Spacer } from "../components/Spacer"
 import { SubscribeForm } from "../components/SubscribeForm"
 import { Sans } from "../components/Typography"
-import { take } from "lodash"
-
-import { releases } from "../data"
+import { BorderBox } from "../components/BorderBox"
 import blogRelease1 from "../assets/releases/large_UW26.jpg"
-import { Spacer } from "../components/Spacer"
 
 const RELEASE_CAP = 9
 
@@ -17,16 +17,16 @@ export const Home = () => {
       <Flex flexWrap="wrap" justifyContent="space-between">
         {take(releases, RELEASE_CAP).map((release, key) => {
           return (
-            <Box width="30%" mb="4%" key={key}>
-              <Image src={release.images[0]} />
+            <Box width={["100%", "30%"]} mb={[4, "4%"]} key={key}>
+              <Image width="100%" src={release.images[0]} />
             </Box>
           )
         })}
       </Flex>
 
       <Box mt={8}>
-        <Flex>
-          <Box width="70%" pr={10}>
+        <Flex flexDirection={["column", "row"]}>
+          <Box width={["100%", "70%"]} pr={[0, 10]}>
             <Box>
               <Box>
                 <Sans size={5} weight="bold">
@@ -75,8 +75,10 @@ export const Home = () => {
               </Box>
             </Box>
           </Box>
-          <Box width="30%">
-            <SubscribeForm />
+          <Box width={["100%", "30%"]} my={[4, 0]}>
+            <BorderBox borderColor="white">
+              <SubscribeForm />
+            </BorderBox>
 
             <Spacer my={5} />
 

--- a/static-layout/src/theme.jsx
+++ b/static-layout/src/theme.jsx
@@ -2,7 +2,7 @@ import { createGlobalStyle } from "styled-components"
 import backgroundImage from "./assets/background-gradient.png"
 import { Link } from "rebass"
 
-const breakpoints = {
+export const breakpoints = {
   xl: 1200,
   lg: 1024,
   md: 900,
@@ -20,6 +20,7 @@ export const theme = {
     black30: "#C2C2C2",
     black10: "#E5E5E5",
     black5: "#F8F8F8",
+    white: "#fff",
 
     purpleLight: "#deb6da",
     purpleDark: "#ce6fc4",

--- a/static-layout/yarn.lock
+++ b/static-layout/yarn.lock
@@ -715,7 +715,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
-"@babel/runtime@7.3.1", "@babel/runtime@^7.1.2":
+"@babel/runtime@7.3.1", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
   integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
@@ -5775,6 +5775,13 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=
+  dependencies:
+    string-convert "^0.2.0"
+
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -7850,7 +7857,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.4, prop-types@^15.6.1:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.1:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8101,6 +8108,16 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-media@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/react-media/-/react-media-1.9.2.tgz#423ee12f952e1d69f1b994a58d3cbed21a92b370"
+  integrity sha512-JUYECMcJIm0V61LSVKd1e+II4ZTYO0GuR7xtlvKETlmThZ416BqZjZdJ1uGqgmMAGFeJ3TG4TX/3Kg4qbR3EJw==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.2"
+    json2mq "^0.2.0"
+    prop-types "^15.5.10"
+
 react-proptype-conditional-require@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/react-proptype-conditional-require/-/react-proptype-conditional-require-1.0.4.tgz#69c2d5741e6df5e08f230f36bbc2944ee1222555"
@@ -8190,6 +8207,13 @@ react@^16.8.2:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.13.2"
+
+reactn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/reactn/-/reactn-1.0.0.tgz#e521d9bab4cd0de75777cabbe2b327a994783243"
+  integrity sha512-6i0KHxHZsIz3XNOHZe9LErrYMXMrADfAGzgNS3+Hd+BFTocJJb4f8myIZOvXCkrDGW0ALpqPnLjrFFwBUdmimA==
+  dependencies:
+    use-force-update "^1.0.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -9122,6 +9146,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -9756,6 +9785,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-force-update@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/use-force-update/-/use-force-update-1.0.2.tgz#9b9668f9dff2f4b8c7c04e26fd64a1bf05be7c28"
+  integrity sha512-/DOz91GCBRg/xMWx9+23JJvo4jLUiksnL4d+OFbbeJEm7BV5Ckn+y+1Z527niwhK8xcHh4zFgkPBtzWyrMkEyg==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This PR starts adding mobile responsiveness by adding some underlying architecture, adding a mobile nav, and applying styles to the homepage. Still need to do the rest. 

There's lots of stuff going on in here, but the most important detail is our UI library rebass innovated an idea called "responsive props". What this means is that you can pass an array to a layout prop if you have [breakpoints wired into the theme](https://github.com/Unseen-Worlds/unseenworlds.github.io/blob/master/static-layout/src/theme.jsx#L14) it will match depending on the breakpoint and apply that value to the prop. The first item in the array is `xs` (extra small, mobile); the second is `small`, the third `medium` (and so on). You don't need to include _all_ breakpoints, though; it will take the last one in the array and apply it to all larger breakpoints.

So for example: 

```js
<Box width="25%">...</Box>
```
At all times this box is 25% width of the browser. 

On a mobile phone, though, I want it to stretch to 100% of the width and fill up the small screen. It's easy with responsive props...

```js
<Box width={["100%", "25%"]}>...</Box>
```

First item in the array is `xs`, second is `sm` -- which then applies all the way up to every other size. 

Responsive props work for all properties [in rebass](https://rebassjs.org/getting-started).

Note that the responsive props concept is new, but its pretty incredible and makes building responsive interfaces really easy and fast. It's starting to spread to other libraries and I imagine it will be quite common in the future. 

![responsiveness](https://user-images.githubusercontent.com/236943/53298287-72d0cf80-37e0-11e9-9e15-b17c902f3561.gif)
