### PR TITLE
Fix navigation link to artist page

### DIFF
--- a/static-layout/src/routes/Artists.jsx
+++ b/static-layout/src/routes/Artists.jsx
@@ -17,7 +17,7 @@ export const Artists = props => {
               key={index}
               mb={8}
               width="30%"
-              onClick={() => props.navigate("/release")}
+              onClick={() => props.navigate("/artist")}
             >
               <Box>
                 <ArtistImage


### PR DESCRIPTION
Noticed that when clicking on an Artist it sent the user to a release, rather than to the artist page. 