### PR TITLE
Finish responsive layouts

### DIFF
--- a/static-layout/src/components/Button.jsx
+++ b/static-layout/src/components/Button.jsx
@@ -16,8 +16,7 @@ export const Button = ({ children, variant, ...rest }) => {
       default: {
         return {
           bg: "teal",
-          px: 1,
-          py: "5px",
+          py: "3px",
         }
       }
     }
@@ -36,4 +35,14 @@ export const Button = ({ children, variant, ...rest }) => {
 const ButtonWrapper = styled(ButtonBase)`
   color: white;
   white-space: nowrap;
+  border-radius: 3px;
+  justify-content: center;
+  display: flex;
+`
+
+export const BuyButton = styled(Button).attrs({
+  mb: 1,
+  mr: ["5px", 0],
+})`
+  width: 100px;
 `

--- a/static-layout/src/components/Layout.jsx
+++ b/static-layout/src/components/Layout.jsx
@@ -22,7 +22,7 @@ export const Layout = ({ children }) => {
           <>
             <Logo />
             <Navigation />
-            <Box mt={8}>{children}</Box>
+            <Box mt={[3, 8]}>{children}</Box>
           </>
         )}
       </Container>

--- a/static-layout/src/components/Logo.jsx
+++ b/static-layout/src/components/Logo.jsx
@@ -1,32 +1,24 @@
 import React from "react"
 import { Box, Flex } from "rebass"
-import Media from "react-media"
 import { Link } from "@reach/router"
 import { ReactComponent as LogoDesktop } from "../assets/LogoDesktop.svg"
 import { ReactComponent as LogoMobile } from "../assets/LogoMobile.svg"
-import { breakpoints } from "../theme"
+import { Mobile, Desktop } from "./Responsive"
 
 export const Logo = () => {
   return (
     <Flex justifyContent="center">
       <Link to="/">
-        <Media query={{ maxWidth: breakpoints.sm }}>
-          {mobile => {
-            if (mobile) {
-              return (
-                <Box mt={4}>
-                  <LogoMobile width={100} />
-                </Box>
-              )
-            } else {
-              return (
-                <Box width={370} height={90}>
-                  <LogoDesktop />
-                </Box>
-              )
-            }
-          }}
-        </Media>
+        <Mobile>
+          <Box mt={1}>
+            <LogoMobile width={100} />
+          </Box>
+        </Mobile>
+        <Desktop>
+          <Box width={370} height={90}>
+            <LogoDesktop />
+          </Box>
+        </Desktop>
       </Link>
     </Flex>
   )

--- a/static-layout/src/components/Navigation.jsx
+++ b/static-layout/src/components/Navigation.jsx
@@ -1,14 +1,12 @@
 import React from "react"
 import { Box, Flex, Image } from "rebass"
 import { Link } from "@reach/router"
-import Media from "react-media"
 import styled from "styled-components"
 import { useGlobal } from "reactn"
-import { color } from "../theme"
-import { Serif } from "./Typography"
-import { Spacer } from "./Spacer"
-import { breakpoints } from "../theme"
+import { color, breakpoints } from "../theme"
+import { Serif, Sans } from "./Typography"
 import { ReactComponent as NavToggle } from "../assets/NavToggle.svg"
+import { Mobile, Desktop, RenderIf } from "./Responsive"
 
 const LinkItem = props => {
   return (
@@ -27,18 +25,6 @@ const LinkItem = props => {
           {props.children}
         </Link>
       </Serif>
-    </Box>
-  )
-}
-
-const SocialLink = props => {
-  const size = [40, 20]
-
-  return (
-    <Box width={size} height={size} mt={1} m={[1, "3px"]}>
-      <a href={props.url} target="_blank" rel="noopener noreferrer">
-        <Image src={props.image} />
-      </a>
     </Box>
   )
 }
@@ -62,31 +48,37 @@ const SocialItems = () => {
   return (
     <Flex
       flexWrap={["wrap", ""]}
-      px={[2, 0]}
-      justifyContent="flex-end"
+      flexDirection={["column", "row"]}
+      justifyContent={["flex-start", "flex-end"]}
       width="100%"
     >
       <SocialLink
+        label="Bandcamp"
         url="https://unseenworlds.bandcamp.com/"
         image={require("../assets/social/rounded-bandcamp.png")}
       />
       <SocialLink
+        label="Spotify"
         url="https://open.spotify.com/user/unseenworlds"
         image={require("../assets/social/rounded-spotify.png")}
       />
       <SocialLink
+        label="Apple Music"
         url="https://itunes.apple.com/profile/unseenworlds"
         image={require("../assets/social/rounded-apple-music.png")}
       />
       <SocialLink
+        label="Twitter"
         url="https://twitter.com/Unseen_Worlds"
         image={require("../assets/social/rounded-twitter.png")}
       />
       <SocialLink
+        label="Instagram"
         url="https://www.instagram.com/unseen_worlds"
         image={require("../assets/social/rounded-instagram.png")}
       />
       <SocialLink
+        label="Facebook"
         url="https://www.facebook.com/unseenworlds"
         image={require("../assets/social/rounded-facebook.png")}
       />
@@ -94,17 +86,41 @@ const SocialItems = () => {
   )
 }
 
+const SocialLink = props => {
+  const size = [30, 20]
+
+  return (
+    <>
+      <Desktop>
+        <Box width={size} height={size} mt={1} pt={1} m={[1, "5px"]}>
+          <a href={props.url} target="_blank" rel="noopener noreferrer">
+            <Image src={props.image} />
+          </a>
+        </Box>
+      </Desktop>
+      <Mobile>
+        <Sans size="2">
+          <a href={props.url} target="_blank" rel="noopener noreferrer">
+            <Box width={size} height={size} mt={1} ml={2} mb={1}>
+              <Image src={props.image} /> {props.label}
+            </Box>
+          </a>
+        </Sans>
+      </Mobile>
+    </>
+  )
+}
+
 export const Navigation = () => {
   return (
-    <Media query={{ maxWidth: breakpoints.sm }}>
-      {mobile => {
-        if (mobile) {
-          return <MobileNavigation />
-        } else {
-          return <DesktopNavigation />
-        }
-      }}
-    </Media>
+    <>
+      <Mobile>
+        <MobileNavigation />
+      </Mobile>
+      <Desktop>
+        <DesktopNavigation />
+      </Desktop>
+    </>
   )
 }
 
@@ -112,7 +128,9 @@ const DesktopNavigation = () => {
   return (
     <Container my={5} alignItems="center" flexDirection="row">
       <NavItems />
-      <SocialItems />
+      <RenderIf greaterThan={breakpoints.lg}>
+        <SocialItems />
+      </RenderIf>
     </Container>
   )
 }
@@ -129,15 +147,9 @@ const MobileNavigation = () => {
         }}
       />
       {isOpen && (
-        <Container
-          my={5}
-          alignItems="flex-start"
-          flexDirection="row"
-          width="100%"
-        >
+        <Container my={5} alignItems="flex-start" width="100%">
           <NavItems />
-          <Spacer my={2} />
-          <SocialItems />
+          {/* <SocialItems /> */}
         </Container>
       )}
     </MobileContainer>

--- a/static-layout/src/components/Responsive.jsx
+++ b/static-layout/src/components/Responsive.jsx
@@ -1,0 +1,41 @@
+import React from "react"
+import Media from "react-media"
+import { breakpoints } from "../theme"
+
+export const Mobile = ({ children }) => {
+  return <MediaWrapper target="mobile">{children}</MediaWrapper>
+}
+
+export const Desktop = ({ children }) => {
+  return <MediaWrapper target="desktop">{children}</MediaWrapper>
+}
+
+const MediaWrapper = ({ target, children }) => {
+  return (
+    <Media query={{ maxWidth: breakpoints.sm }}>
+      {mobile => {
+        switch (target) {
+          case "mobile":
+            return mobile ? children : null
+          // Desktop
+          default:
+            return mobile ? null : children
+        }
+      }}
+    </Media>
+  )
+}
+
+export const RenderIf = ({ greaterThan, children }) => {
+  return (
+    <Media query={{ minWidth: greaterThan }}>
+      {match => {
+        if (match) {
+          return children
+        } else {
+          return null
+        }
+      }}
+    </Media>
+  )
+}

--- a/static-layout/src/routes/About.jsx
+++ b/static-layout/src/routes/About.jsx
@@ -6,9 +6,9 @@ import { BorderBox } from "../components/BorderBox"
 
 export const About = () => {
   return (
-    <Flex>
-      <Box width="60%" pr={3}>
-        <Sans size="6">
+    <Flex flexDirection={["column", "row"]}>
+      <Box width={["100%", "60%"]} pr={[0, 3]}>
+        <Sans size={["5", "6"]}>
           Unseen Worlds is a record label releasing quality editions of
           unheralded and revolutionary, yet accessible, avant garde music. We
           are interested in media that capture a timeless ecstasy of creativity,
@@ -21,7 +21,7 @@ export const About = () => {
 
         <Spacer my={4} />
 
-        <Sans size="5">
+        <Sans size="4">
           <p>
             You may get in touch with us at{" "}
             <a href="#f">unseenworlds@unseenworlds.com</a> <br />
@@ -37,7 +37,7 @@ export const About = () => {
           </p>
         </Sans>
       </Box>
-      <BorderBox width="40%">
+      <BorderBox width={["100%", "40%"]} my={[2, 0]}>
         Our titles see distribution worldwide via Secretly Distribution
         <p>
           Direct Retail Sales: <br />

--- a/static-layout/src/routes/AllReleases.jsx
+++ b/static-layout/src/routes/AllReleases.jsx
@@ -1,9 +1,8 @@
 import React from "react"
 import { Box, Image, Flex } from "rebass"
-
 import { releases } from "../data"
 import { Sans } from "../components/Typography"
-import { Button } from "../components/Button"
+import { BuyButton } from "../components/Button"
 import { Spacer } from "../components/Spacer"
 
 export const AllReleases = () => {
@@ -11,12 +10,12 @@ export const AllReleases = () => {
     <Box>
       {releases.reverse().map((release, key) => {
         return (
-          <Box mb={4} key={key}>
-            <Flex>
-              <Box width="40%" pr={6}>
-                <Image height="auto" src={release.images[0]} />
+          <Box mb={[8, 4]} key={key}>
+            <Flex flexDirection={["column", "row"]}>
+              <Box width={["100%", "40%"]} pr={[0, 6]} mb={[3, 0]}>
+                <Image width="100%" height="auto" src={release.images[0]} />
               </Box>
-              <Box width="60%">
+              <Box width={["100%", "60%"]}>
                 <Sans size="5" weight="black" color="black80">
                   {release.artist.name}
                 </Sans>
@@ -33,16 +32,14 @@ export const AllReleases = () => {
 
                 <Spacer my={2} />
 
-                <Sans size="3" weight="semibold">
-                  More Info
+                <Sans size="2" weight="black">
+                  ◮ More Info
                 </Sans>
 
-                <Flex flexDirection="row" width="100%">
-                  <Button>CD - $11.00</Button>
-                  <Spacer mr={1} />
-                  <Button>DIGITAL - $7.00</Button>
-                  <Spacer mr={1} />
-                  <Button>LP - $18.00</Button>
+                <Flex flexDirection={"column"} mt={2}>
+                  <BuyButton>CD - $11.00</BuyButton>
+                  <BuyButton>DIGITAL - $7.00</BuyButton>
+                  <BuyButton>LP - $18.00</BuyButton>
                 </Flex>
               </Box>
             </Flex>

--- a/static-layout/src/routes/Artist.jsx
+++ b/static-layout/src/routes/Artist.jsx
@@ -8,24 +8,13 @@ export const Artist = () => {
 
   return (
     <Box>
-      <Flex>
-        <Box width="70%" pr={8}>
+      <Flex flexDirection={["column", "row"]}>
+        <Box width={["100%", "70%"]} pr={[0, 8]}>
           <Box>
             <Sans size="7" weight="light" color="teal">
               {artist.name}
             </Sans>
           </Box>
-          <Box mt={2} mb={4}>
-            {artist.bio}
-          </Box>
-
-          <Box my={4}>
-            <Image src={artist.videos[0]} />
-          </Box>
-        </Box>
-        <Box width="30%">
-          <Image src={artist.images[1]} />
-
           <Box mt={3} mb={1}>
             <Serif>Releases</Serif>
           </Box>
@@ -35,13 +24,23 @@ export const Artist = () => {
                 <Flex alignItems="center">
                   <Box>
                     <Box>
-                      <Sans>{release.album}</Sans>
+                      <Sans>◮ {release.album}</Sans>
                     </Box>
                   </Box>
                 </Flex>
               )
             })}
           </Box>
+          <Box mt={2} mb={4}>
+            {artist.bio}
+          </Box>
+
+          <Box my={4}>
+            <Image src={artist.videos[0]} />
+          </Box>
+        </Box>
+        <Box width={["100%", "30%"]}>
+          <Image src={artist.images[1]} />
         </Box>
       </Flex>
     </Box>

--- a/static-layout/src/routes/Artists.jsx
+++ b/static-layout/src/routes/Artists.jsx
@@ -15,8 +15,8 @@ export const Artists = props => {
           return (
             <Artist
               key={index}
-              mb={8}
-              width="30%"
+              mb={[2, 8]}
+              width={["100%", "48%", "48%", "30%"]}
               onClick={() => props.navigate("/artist")}
             >
               <Box>
@@ -26,9 +26,9 @@ export const Artists = props => {
                   height={300}
                 />
 
-                <Spacer my={3} />
+                <Spacer my={[2, 3]} />
 
-                <Flex>
+                <Flex flexDirection={["column", "row"]}>
                   <Box pr={2}>
                     <Sans size="6" weight="light" color="teal">
                       <Link to="/artist" style={{ whitespace: "nowrap" }}>
@@ -36,11 +36,11 @@ export const Artists = props => {
                       </Link>
                     </Sans>
                   </Box>
-                  <Box mt="8px">
+                  <AlbumList>
                     {artist.releases.map((release, index) => {
                       return (
-                        <Box mb="5px" key={index}>
-                          <Sans size="3" weight="regular">
+                        <li key={index}>
+                          <Sans size={["4", "3"]} weight="regular">
                             <Link
                               to="/release"
                               onClick={event => event.stopPropagation()}
@@ -48,10 +48,10 @@ export const Artists = props => {
                               {release.album}
                             </Link>
                           </Sans>
-                        </Box>
+                        </li>
                       )
                     })}
-                  </Box>
+                  </AlbumList>
                 </Flex>
               </Box>
             </Artist>
@@ -78,4 +78,21 @@ const Artist = styled(Box)`
 
 const ArtistImage = styled(Image)`
   object-fit: cover;
+`
+
+const AlbumList = styled.ul`
+  position: relative;
+  padding-left: 10px;
+  list-style-type: none;
+  top: -8px;
+  margin-left: 10px;
+
+  li {
+    /* margin-bottom: 2px; */
+    &:before {
+      content: "◮";
+      position: absolute;
+      left: -5px;
+    }
+  }
 `

--- a/static-layout/src/routes/Ephemera.jsx
+++ b/static-layout/src/routes/Ephemera.jsx
@@ -5,12 +5,12 @@ import { Button } from "../components/Button"
 
 export const Ephemera = () => {
   return (
-    <Flex justifyContent="space-between">
+    <Flex flexDirection={["column", "row"]} justifyContent="space-between">
       {merch.map((item, index) => {
         return (
-          <Box key={index} width="30%">
-            <Box>
-              <Image src={item.image} />
+          <Box key={index} width={["100%", "30%"]} mb={[4, 0]}>
+            <Box width={["100%"]}>
+              <Image width={["100%"]} src={item.image} />
             </Box>
             <Box>{item.content}</Box>
             <Box my={2}>

--- a/static-layout/src/routes/Home.jsx
+++ b/static-layout/src/routes/Home.jsx
@@ -17,7 +17,7 @@ export const Home = () => {
       <Flex flexWrap="wrap" justifyContent="space-between">
         {take(releases, RELEASE_CAP).map((release, key) => {
           return (
-            <Box width={["100%", "30%"]} mb={[4, "4%"]} key={key}>
+            <Box width={["100%", "48%", "48%", "30%"]} mb={[4, "4%"]} key={key}>
               <Image width="100%" src={release.images[0]} />
             </Box>
           )

--- a/static-layout/src/routes/News.jsx
+++ b/static-layout/src/routes/News.jsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Flex, Box } from "rebass"
 import { Sans } from "../components/Typography"
 import { posts } from "../data"
+import { Spacer } from "../components/Spacer"
 
 export const News = () => {
   return (
@@ -9,14 +10,15 @@ export const News = () => {
       {posts.map((post, index) => {
         return (
           <Box key={index}>
-            <Flex mb={4}>
-              <Box width="40%" pr={6}>
+            <Flex flexDirection={["column", "row"]} mb={4}>
+              <Box width={["100%", "40%"]} pr={[0, 6]}>
                 <Sans size="6" weight="light">
                   {post.title}
                 </Sans>
                 <Sans color="black30">{post.date}</Sans>
               </Box>
-              <Box width="60%">{post.content}</Box>
+              <Spacer my={[1, 0]} />
+              <Box width={["100%", "60%"]}>{post.content}</Box>
             </Flex>
           </Box>
         )

--- a/static-layout/src/routes/Release.jsx
+++ b/static-layout/src/routes/Release.jsx
@@ -3,21 +3,26 @@ import { Box, Image, Flex } from "rebass"
 import { Sans, Serif } from "../components/Typography"
 import { releases, badges } from "../data"
 import { Spacer } from "../components/Spacer"
-import { Button } from "../components/Button"
+import { BuyButton } from "../components/Button"
 import { sample } from "lodash"
 
 import samAshleyPhoto from "../assets/large_Sam_Ashley.jpg"
+import { Desktop } from "../components/Responsive"
 
 export const Release = () => {
   const release = releases.find(release => release.id === "UW23")
 
   return (
     <Box>
-      <Flex justifyContent="space-between">
-        <Box pr={6}>
-          <Flex>
-            <Box pr={5}>
-              <Image width="398px" height="auto" src={release.images[0]} />
+      <Flex justifyContent="space-between" flexDirection={["column", "row"]}>
+        <Box pr={[0, 6]}>
+          <Flex flexDirection={["column", "row"]}>
+            <Box pr={[0, 5]}>
+              <Image
+                width={["100%", "398px"]}
+                height="auto"
+                src={release.images[0]}
+              />
             </Box>
             <Box>
               <Sans size="5" weight="black" color="black80">
@@ -36,47 +41,55 @@ export const Release = () => {
                 <Sans size="2">All items include instant download</Sans>
               </Box>
 
-              <Flex flexDirection="row" width="100%">
-                <Button>CD - $11.00</Button>
-                <Spacer mr={1} />
-                <Button>DIGITAL - $7.00</Button>
-                <Spacer mr={1} />
-                <Button>LP - $18.00</Button>
+              <Flex flexDirection={["row", "column"]} mt={2}>
+                <BuyButton>CD - $11.00</BuyButton>
+                <BuyButton>DIGITAL - $7.00</BuyButton>
+                <BuyButton>LP - $18.00</BuyButton>
               </Flex>
 
-              <Box my={5} style={{ opacity: 0.7 }}>
-                <Image src={badges.apple} height={30} /> <br />
+              <Box my={3} style={{ opacity: 0.7 }}>
+                <Image src={badges.apple} height={30} mr={["5px", 0]} /> <br />
                 <Image src={badges.spotify} height={30} />
               </Box>
             </Box>
           </Flex>
         </Box>
 
-        <Box>
+        <Desktop>
           <Box>
-            <Image
-              src={samAshleyPhoto}
-              width={200}
-              height={200}
-              style={{ objectFit: "cover" }}
-            />
-          </Box>
-          <Box my={2}>
-            <Box my={2}>
-              <Serif size="5">You May Also Like</Serif>
+            <Box>
+              <Image
+                src={samAshleyPhoto}
+                width={200}
+                height={200}
+                style={{ objectFit: "cover" }}
+              />
             </Box>
-            <Flex justifyContent="space-between">
-              <Image src={sample(releases).images[0]} width={90} height={90} />
-              <Image src={sample(releases).images[0]} width={90} height={90} />
-            </Flex>
+            <Box my={2}>
+              <Box my={2}>
+                <Serif size="5">You May Also Like</Serif>
+              </Box>
+              <Flex justifyContent="space-between">
+                <Image
+                  src={sample(releases).images[0]}
+                  width={90}
+                  height={90}
+                />
+                <Image
+                  src={sample(releases).images[0]}
+                  width={90}
+                  height={90}
+                />
+              </Flex>
+            </Box>
           </Box>
-        </Box>
+        </Desktop>
       </Flex>
 
-      <Spacer my={5} />
+      <Spacer my={[0, 5]} />
 
       <Flex justifyContent="space-between">
-        <Box width="80%" pr={6}>
+        <Box width={["100%", "80%"]} pr={[0, 6]}>
           <Serif size="6">Release Info</Serif>
 
           <p>
@@ -158,21 +171,23 @@ export const Release = () => {
             with experimental composer and performance artist Sam Ashley
           </p>
         </Box>
-        <Box>
-          <Serif size="5">Track list</Serif>
-          <p>
-            Side A <br />
-            1. I’d Rather Be Lucky Than Good [17:51] <br />
-            <br />
-            Side B <br />
-            2. Love Among The Immortals [21:08]
-          </p>
-          <Box my={3}>
-            <Serif size="5">Links</Serif>
+        <Desktop>
+          <Box>
+            <Serif size="5">Track list</Serif>
+            <p>
+              Side A <br />
+              1. I’d Rather Be Lucky Than Good [17:51] <br />
+              <br />
+              Side B <br />
+              2. Love Among The Immortals [21:08]
+            </p>
+            <Box my={3}>
+              <Serif size="5">Links</Serif>
+            </Box>
+            <a href="#f">Sam Ashley on Lovely Music</a> <br />
+            <a href="#f">Werner Durand homepage</a>
           </Box>
-          <a href="#f">Sam Ashley on Lovely Music</a> <br />
-          <a href="#f">Werner Durand homepage</a>
-        </Box>
+        </Desktop>
       </Flex>
     </Box>
   )


### PR DESCRIPTION
Finishes up the responsive layout work. Need  to come up with a better behavior for the side-nav; that will be next. 

Also adds a few responsive helpers:  `Desktop`, `Mobile` and `RenderIf`, which wraps `Media`. 

![responsiveness2](https://user-images.githubusercontent.com/236943/53313289-90984600-386d-11e9-8437-df085f4287ad.gif)
